### PR TITLE
Fix on initial-setup.sh script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 .gradle
 .idea
+.settings
+.project
+.classpath
+bin/
 build/
 target/
 logs/

--- a/scripts/Unix/initial-setup.sh
+++ b/scripts/Unix/initial-setup.sh
@@ -47,8 +47,6 @@ cd ..
 mkdir tools
 cd tools
 
-cd ..
-
 # REM initialize fineract-cn-crypto
 git clone https://github.com/$githubAccount/fineract-cn-crypto.git
 cd fineract-cn-crypto


### PR DESCRIPTION
The initial-setup.sh script creates tools directory and the next command executed was cd .. which takes you out of tools directory before cloning fineract-cn-crypto. 