### PR TITLE
Add ability to restrict working set of microservices 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,8 @@ gradle-app.setting
 !gradle-wrapper.jar
 
 *.iml
-
+*.ipr
+*.iws
 *.log
 
 *.toDelete

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Run in persistent mode and to NOT use embedded datastores
 ##### demoserver.provision (true/false)
 Run the provision steps against the services to bootstrap tenants
 
+##### demoserver.lite (true/false)
+Enabling lite mode (defaults to false) restricts the working set of micro-services to Provisioner, Identity, Rhythm, Organization and Customer
+
 ##### custom.cassandra.contactPoints
 Custom cassandra contact points (multiple values allowed separated by comma e.g. 127.0.0.1:9042,127.0.0.2:9042)
 


### PR DESCRIPTION
Adding a new flag -Ddemoserver.lite , which when set to true restricts the working set of micro-services to Provisioner, Identity, Rhythm, Organization and Customer.

*Note : most of the diffs shown are related to whitespaces, adding ?w=1 to compare view on GitHub provides an cleaner view of the changes