### PR TITLE
simplify running demo-server by fetching fineract-cn-* projects from Artifactory

### DIFF
--- a/scripts/dependencies_to_local_maven/pom.xml
+++ b/scripts/dependencies_to_local_maven/pom.xml
@@ -1,0 +1,225 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+READ ME FIRST:
+
+This script gets all dependent fineract-cn-* projects from Fineract Artifactory into mavenLocal
+ without building the projects locally. More info:
+ https://cwiki.apache.org/confluence/display/FINERACT/How+To+Build+Apache+Fineract+CN
+
+ -->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.fineract.cn</groupId>
+  <artifactId>demo-server-helper</artifactId>
+  <version>0.1.0-BUILD-SNAPSHOT</version>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <repositories>
+    <repository>
+      <id>fineract-artifactory</id>
+      <url>https://mifos.jfrog.io/mifos/libs-snapshot/</url>
+    </repository>
+  </repositories>
+
+  <!-- we don't want to install this artifact to local Maven repository if user runs "mvn install" -->
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>default-install</id>
+              <phase>none</phase>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.fineract.cn.office</groupId>
+      <artifactId>service-boot</artifactId>
+      <version>0.1.0-BUILD-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.fineract.cn.provisioner</groupId>
+      <artifactId>service-boot</artifactId>
+      <version>0.1.0-BUILD-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.fineract.cn.identity</groupId>
+      <artifactId>service-boot</artifactId>
+      <version>0.1.0-BUILD-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.fineract.cn.rhythm</groupId>
+      <artifactId>service-boot</artifactId>
+      <version>0.1.0-BUILD-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.fineract.cn.customer</groupId>
+      <artifactId>service-boot</artifactId>
+      <version>0.1.0-BUILD-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.fineract.cn.accounting</groupId>
+      <artifactId>service-boot</artifactId>
+      <version>0.1.0-BUILD-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.fineract.cn.portfolio</groupId>
+      <artifactId>service-boot</artifactId>
+      <version>0.1.0-BUILD-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.fineract.cn.deposit-account-management</groupId>
+      <artifactId>service-boot</artifactId>
+      <version>0.1.0-BUILD-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.fineract.cn.teller</groupId>
+      <artifactId>service-boot</artifactId>
+      <version>0.1.0-BUILD-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.fineract.cn.reporting</groupId>
+      <artifactId>service-boot</artifactId>
+      <version>0.1.0-BUILD-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.fineract.cn.cheques</groupId>
+      <artifactId>service-boot</artifactId>
+      <version>0.1.0-BUILD-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.fineract.cn.payroll</groupId>
+      <artifactId>service-boot</artifactId>
+      <version>0.1.0-BUILD-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.fineract.cn.group</groupId>
+      <artifactId>service-boot</artifactId>
+      <version>0.1.0-BUILD-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.fineract.cn.notification</groupId>
+      <artifactId>service-boot</artifactId>
+      <version>0.1.0-BUILD-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+  </dependencies>
+</project>


### PR DESCRIPTION
The simplified instructions to run demo-server would look like this:

git clone https://github.com/apache/fineract-cn-demo-server.git
cd fineract-cn-demo-server/
cd  scripts/dependencies_to_local_maven
mvn package    
cd ../..
./gradlew build

This pom.xml pulls required dependencies to local maven repository. build.gradle cannot be used for this as this downloads the artifacts to Gradle cache (and there is no way to force Gradle to upload them to maven local).